### PR TITLE
Add _t shortcut function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,12 @@ Once you’ve initialised it with a dictionary, you can translate strings using 
 $('div#example').text($.i18n._('some text'));
 ```
 
+or using $('selector')._t() function
+
+```javascript
+$('div#example')._t('some text');
+```
+
 Wildcards
 ---------
 
@@ -44,6 +50,12 @@ Next, pass an array of values in as the second argument when you perform the tra
 
 ```javascript
 $('div#example').text($.i18n._('wildcard example', [100, 200]));
+```
+
+or
+
+```javascript
+$('div#example')._t('wildcard example', [100, 200]);
 ```
 
 This will output _We have been passed two values : 100 and 200._

--- a/jquery.i18n.js
+++ b/jquery.i18n.js
@@ -7,7 +7,7 @@
  * Licensed under the MIT license:
  *   http://www.opensource.org/licenses/mit-license.php
  *
- * Version: 0.9.1 (201012171436)
+ * Version: 0.9.1 (201109152239)
  */
  (function($) {
 /**
@@ -125,6 +125,20 @@ $.i18n = {
 		return nS + tS[tS.length-1];
 	}
 
+};
+
+/*
+ * _t
+ * Allows you to translate a jQuery selector
+ *
+ * eg $('h1')._t('some text')
+ * 
+ * @param string str : The string to translate 
+ * @param property_list params : params for using printf() on the string
+ * @return element : chained and translated element(s)
+*/
+$.fn._t = function(str, params) {
+  return $(this).text($.i18n._(str, params));
 };
 
 

--- a/src/jquery.i18n.js
+++ b/src/jquery.i18n.js
@@ -127,5 +127,19 @@ $.i18n = {
 
 };
 
+/*
+ * _t
+ * Allows you to translate a jQuery selector
+ *
+ * eg $('h1')._t('some text')
+ * 
+ * @param string str : The string to translate 
+ * @param property_list params : params for using printf() on the string
+ * @return element : chained and translated element(s)
+*/
+$.fn._t = function(str, params) {
+  return $(this).text($.i18n._(str, params));
+};
+
 
 })(jQuery);


### PR DESCRIPTION
Adds a function that makes it easier to translate selected elements:

$('div#example')._t('some string');
