### PR TITLE
Fix incorrect behavior if a string that begins with %s is passed to printf

### DIFF
--- a/jquery.i18n.js
+++ b/jquery.i18n.js
@@ -118,7 +118,7 @@ $.i18n = {
 		var tS = S.split("%s");
 
 		for(var i=0; i<L.length; i++) {
-			if (tS[i].lastIndexOf('%') == tS[i].length-1 && i != L.length-1)
+			if (tS[i].length != 0 && tS[i].lastIndexOf('%') == tS[i].length-1 && i != L.length-1)
 				tS[i] += "s"+tS.splice(i+1,1)[0];
 			nS += tS[i] + L[i];
 		}


### PR DESCRIPTION
Example:

$.i18n.printf("%s and %s are fun", ["foo", "bar"]);

Before:

"s and foo are funbar are fun"

After:

"foo and bar are fun"

Reason: 

In line 121 this test returns true because the lastIndexOf returns -1 because there is no %s in the empty string and this value matches its length (0) minus 1:

tS[i].lastIndexOf('%') == tS[i].length-1
