### PR TITLE
Fix version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-i18n",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/recurser/jquery-i18n",
   "authors": [
     "Dave Perrett <hello@daveperrett.com>"


### PR DESCRIPTION
Curerntly bower warns when installing with:
`mismatch Version declared in the json (1.1.0) is different than the resolved one (1.1.1)`.

This upgrades the version declaration in bower.json too.
